### PR TITLE
Fixed unintended behaviour of special characters in "thanks *"

### DIFF
--- a/AIML/lib/aiml/_kaleith.aiml
+++ b/AIML/lib/aiml/_kaleith.aiml
@@ -130,17 +130,17 @@
 		<pattern>THANKS *</pattern>
 		<template>
 			<random>
-				<li>:vert: THANKS <uppercase><star/></uppercase> :vert:</li>
-				<li>:Miller: THANKS <uppercase><star/></uppercase> :Miller:</li>
-				<li>:blissful_creep: THANKS <uppercase><star/></uppercase> :blissful_creep:</li>
-				<li>:Neko: THANKS <uppercase><star/></uppercase> :Neko:</li>
-				<li>:bite: THANKS <uppercase><star/></uppercase> :bite:</li>
-				<li>:ojchicken: THANKS <uppercase><star/></uppercase> :ojchicken:</li>
-				<li>:ojseagull: THANKS <uppercase><star/></uppercase> :ojseagull:</li>
-				<li>:VSnake: THANKS <uppercase><star/></uppercase> :VSnake:</li>
-				<li>:shelterfrog: THANKS <uppercase><star/></uppercase> :shelterfrog:</li>
-				<li>:summerghost: THANKS <uppercase><star/></uppercase> :summerghost:</li>
-				<li>:rana: THANKS <uppercase><star/></uppercase> :rana:</li>				
+				<li>:vert: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :vert:</li>
+				<li>:Miller: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :Miller:</li>
+				<li>:blissful_creep: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :blissful_creep:</li>
+				<li>:Neko: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :Neko:</li>
+				<li>:bite: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :bite:</li>
+				<li>:ojchicken: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :ojchicken:</li>
+				<li>:ojseagull: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :ojseagull:</li>
+				<li>:VSnake: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :VSnake:</li>
+				<li>:shelterfrog: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :shelterfrog:</li>
+				<li>:summerghost: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :summerghost:</li>
+				<li>:rana: THANKS <uppercase><denormalize><star/></denormalize></uppercase> :rana:</li>				
 			</random>
 		</template>
 	</category>

--- a/AIML/lib/substitutions/denormal.substitution
+++ b/AIML/lib/substitutions/denormal.substitution
@@ -121,7 +121,6 @@
 [" colon 9", ":9"],
 [" smile ", ";)"],
 [" smile ", ";-)"],
-[" at ", "@"],
 [" atsign ", "@"],
 [" leftbracket ", "["],
 [" forwardslash ", "\""],

--- a/AIML/lib/substitutions/normal.substitution
+++ b/AIML/lib/substitutions/normal.substitution
@@ -426,7 +426,7 @@
 [";", " "],
 [";)", " smile "],
 [";-)", " smile "],
-["@", " at "],
+["@", " atsign "],
 ["[", " leftbracket "],
 ["\"", " forwardslash "],
 ["]", " rightbracket "],


### PR DESCRIPTION
This should let people use emoticons like blissful_creep in the command by using the substitution capability of \<denomalize\> to re-convert the character _ before outputting it. It's not ideal but unless there's a way to create more .substitution files and include them it's the only option I had.

I also made a minor change in normal.substitution and denormal.substitution to let people type the word "at" in a command without it being converted by \<denormalize\>.
This should not affect functionality in any other scenario where normalization or denormalization is used, as I just set the character "@" to be normalized to " atsign " instead of " at " when working with inputs that include it.