### PR TITLE
Omit "and" in provided time strings

### DIFF
--- a/Brain/ArchiBoT/Settings/Scripts.siml
+++ b/Brain/ArchiBoT/Settings/Scripts.siml
@@ -90,7 +90,7 @@ return a[index];
             day: 60 * 60 * 24
         };
 
-        var timeArray = trimTrailingComma(timeString).split(' ');
+        var timeArray = removeFromArray(trimTrailingComma(timeString).split(' '), 'and');
 
         if (timeArray.length === 1) {
             var timeInSeconds = parseInt(timeArray[0], 10); // We assume seconds are the default units
@@ -139,6 +139,21 @@ return a[index];
     function trimTrailingComma(string) {
         if (string[string.length - 1] === ',') return string.slice(0, -1);
         return string;
+    }
+
+    /**
+     * Removes given element from an array
+     * @param {Array} array
+     * @param element
+     */
+    function removeFromArray(array, element) {
+        for (var i = array.length; i--;) {
+            if (array[i] === element) {
+                array.splice(i, 1);
+            }
+        }
+
+        return array;
     }
 </Script>
 </Siml>

--- a/Brain/ArchiBoT/_mole.siml
+++ b/Brain/ArchiBoT/_mole.siml
@@ -15,7 +15,7 @@
                     I'll remind you in <Text>{Time}</Text> to <Text>{Task}</Text>
                     <Late Second="{TimeInSeconds}">Remember to <Text>{Task}</Text></Late>
                 </If>
-                <Else>Sorry, I couldn't parse the time: <Text>{Time}</Text> (<Text>{TimeInSeconds}</Text>)</Else>
+                <Else>Sorry, I couldn't parse the time: <Text>{Time}</Text> (<Text>{TimeInSeconds}</Text> seconds)</Else>
             </Response>
         </Model>
     </Concept>


### PR DESCRIPTION
Adds interesting option to specify `time` with `and` word.
Example: `1 hour and 5 minutes`